### PR TITLE
Update client.py

### DIFF
--- a/src/senaite/core/catalog/indexer/client.py
+++ b/src/senaite/core/catalog/indexer/client.py
@@ -45,4 +45,5 @@ def client_searchable_text(instance):
     tokens = filter(None, set(tokens))
 
     # return a single unicode string with all the concatenated tokens
-    return u" ".join(map(api.safe_unicode, tokens))
+    return u" ".join(map(lambda x: api.safe_unicode(str(x)), tokens))
+


### PR DESCRIPTION
Fix TypeError in client_searchable_text indexer

Wrapped all tokens in str() before passing to api.safe_unicode() to avoid TypeError during LIMS import. This prevents failures when non-string values (e.g., integers) are returned from client fields like phone or tax number.

## Description of the issue/feature this PR addresses (no issue exists yet — this PR addresses a common migration failure due to indexing)
When importing a configuration tarball in Senaite, the client_searchable_text indexer throws:
TypeError: sequence item 4: expected string or Unicode, int found
This is due to one or more client fields returning non-string values.
Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

The portal import fails entirely if any token returned by client_searchable_text is not a string (e.g., an integer in getPhone() or getTaxNumber()). This blocks instance migration between environments.

## Desired behavior after PR is merged

All fields are explicitly cast to string before conversion to Unicode. The indexer becomes resilient to type mismatches and imports succeed without error.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
